### PR TITLE
Fixing a breaking chai-as-promised change

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "chai": "^1.10.0",
-    "chai-as-promised": "^4.1.1",
+    "chai-as-promised": "~4.1.1",
     "cucumber": "^0.4.7",
     "minimist": "^1.1.0",
     "phantomjs": "^1.9.13",


### PR DESCRIPTION
chai-as-promised updated their required chai version to > 2.1, which is breaking builds across the world. this will not use the newest version of chai-as-promised
